### PR TITLE
Upgrade deprecated runtime nodejs8.10

### DIFF
--- a/examples/inbound-call/cloudformation.yaml
+++ b/examples/inbound-call/cloudformation.yaml
@@ -46,7 +46,7 @@ Resources:
       Handler: index.handler
       MemorySize: 256
       Role: !GetAtt InboundLambdaExecutionRole.Arn
-      Runtime: nodejs8.10
+      Runtime: nodejs10.x
       Timeout: 30
       Environment:
         Variables:

--- a/examples/private-bot/cloudformation.yaml
+++ b/examples/private-bot/cloudformation.yaml
@@ -61,5 +61,5 @@ Resources:
       Handler: index.handler
       MemorySize: 256
       Role: !GetAtt PrivateBotLambdaExecutionRole.Arn
-      Runtime: nodejs8.10
+      Runtime: nodejs10.x
       Timeout: 30


### PR DESCRIPTION
CloudFormation templates in amazon-chime-private-bot-demo have been found to include a [deprecated Lambda function runtime](https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html) (nodejs8.10). The affected templates have been updated to a supported runtime (nodejs10.x).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.